### PR TITLE
Add inject-react-anywhere

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Code meant become part of the extension.
 - [@types/firefox-webext-browser](https://www.npmjs.com/package/@types/firefox-webext-browser) - Supplies TypeScript types for the `browser` namespace.
 - [redux-webext](https://github.com/ivantsov/redux-webext) - Uses Redux for managing the state of your WebExtension.
 - [ExtPay](https://github.com/Glench/ExtPay) - Take secure payments in extensions without needing to run a server backend.
+- [inject-react-anywhere](https://github.com/OlegWock/inject-react-anywhere) - Inject React components into 3rd party sites with convenient API and styles isolation.
 - [More…](https://github.com/fregante/webext-fun)
 
 ## Tools


### PR DESCRIPTION
I added my library which can be used to easily inject React components onto 3rd-party sites. It uses Shadow DOM under hood and allows to effectively isolate component from parent site without iframe's downsides.

And maybe you know any other resources where I can post my library so more developers will see it. I'll very appreciate if you share them